### PR TITLE
possom-bootstrap // java.lang.ClassNotFoundException

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -202,6 +202,7 @@
         <dependency>
             <groupId>sesat</groupId>
             <artifactId>sesat-user-api</artifactId>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
reverting the following commit:
https://github.com/michaelsembwever/Possom/commit/a5ef98fe9d264fd48d1829f96538512f7a52844f

> ensure sesat-user is in WEB-INF/lib
